### PR TITLE
Fix columns order

### DIFF
--- a/docs/spec/examples/multiple-runs-single-block/index.md
+++ b/docs/spec/examples/multiple-runs-single-block/index.md
@@ -41,6 +41,6 @@ daily-deadhead-2,daily,BLOCK-A,,,104,,
 
 ```csv
 run_id,piece_id,start_type,start_trip_id,start_trip_position,end_type,end_trip_id,end_trip_position
-10000,10000-1,,0,daily-deadhead-1,,1,102,
-20000,20000-2,,1,103,,0,daily-deadhead-2,
+10000,10000-1,0,daily-deadhead-1,,1,102,,
+20000,20000-2,1,103,,0,daily-deadhead-2,,
 ```


### PR DESCRIPTION
Seems like the empty column was in the wrong position, as 0 and 1 values should be the `start-type` and not `start-trip-id`