### PR TITLE
Restructure ODS to "Supplement" Framework

### DIFF
--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,54 +1,63 @@
+
 # Reference
 
-The Operational Data Standard was last updated on April 14, 2022 (v1.0). View the full [revision history](./revision-history.md).
+The Transit Operational Data Standard was last updated on February 27, 2024 (v2.0). View the full [revision history](./revision-history.md).
+
 
 ## Dataset Files
 
-| **File Name** | **Description** |
-| --- | --- |
-| deadheads.txt | Defines scheduled deadheads contained in a transit feed. (This file is analogous to [trips.txt](https://developers.google.com/transit/gtfs/reference#tripstxt) for non-revenue operations.) |
-| ops_locations.txt | Significant operational locations relevant to the performance of vehicle deadheads. (This file is analogous to [stops.txt](https://developers.google.com/transit/gtfs/reference#stopstxt) for non-revenue operations.) |
-| deadhead_times.txt | Times that a vehicle arrives at and departs from operational locations for each deadhead. (This file is analogous to [stop_times.txt](https://developers.google.com/transit/gtfs/reference#stop_timestxt) for non-revenue operations.) |
-| runs_pieces.txt | Defines daily personnel schedules within a feed. |
-| run_events.txt | Defines other scheduled activities to be performed by a member of personnel during a run. |
+### Structure
 
-## Field Definitions
+There are two types of files used in the TODS standard:
 
-### deadheads.txt
+- **`_supplement` files**, used to add, modify, and delete information from public GTFS files to model the operational service for internal purposes.
+- **TODS-specific files**, used to model operational elements not currently defined in the GTFS standard.
 
-| **Field Name** | **Type** | **Required** | **Description** |
-| --- | --- | --- | --- |
-| deadhead_id | ID | Required | Identifies a deadhead. |
-| service_id | ID referencing [**calendar.service_id**](https://developers.google.com/transit/gtfs/reference#calendartxt) | Required | Identifies a set of dates when the deadhead is scheduled to take place. |
-| block_id | ID | Required | Identifies the block to which the deadhead belongs. |
-| shape_id | ID referencing [**shapes.shape_id**](https://developers.google.com/transit/gtfs/reference#shapestxt) | Optional | Identifies a geospatial shape that describes the vehicle travel path for a deadhead. |
-| to_trip_id | ID referencing [**trips.trip_id**](https://developers.google.com/transit/gtfs/reference#tripstxt) | Conditionally Required | Identifies the trip scheduled immediately following to the deadhead within the block_id. |
-| from_trip_id | ID referencing [**trips.trip_id**](https://developers.google.com/transit/gtfs/reference#tripstxt) | Conditionally Required | Identifies the trip scheduled immediately prior to the deadhead within the block_id. |
-| to_deadhead_id | ID referencing **deadheads.deadhead_id** | Conditionally Required | Identifies the deadhead scheduled immediately following the deadhead within the block_id. |
-| from_deadhead_id | ID referencing **deadheads.deadhead_id** | Conditionally Required | Identifies the deadhead scheduled immediately prior to the deadhead within the block_id. |
 
-### ops_locations.txt
+### Files
+  
+| **File Name** | **Type** | **Description** |
+| --- | --- | --- |
+| trips_supplement.txt | Supplement | Supplements and modifies GTFS [trips.txt](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#tripstxt) with deadheads and other non-public trip information.|
+| stops_supplement.txt | Supplement | Supplements and modifies GTFS [stops.txt](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stopstxt) with internal stop locations, waypoints, and other non-public stop information.|
+| stop_times_supplement.txt | Supplement | Supplements and modifies GTFS [stop_times.txt](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stop_timestxt) with non-public times that trips stop at locations, and related information. |
+| routes.txt | Supplement | Supplements and modifies GTFS [routes.txt](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#routestxt) with internal route identifiers and other non-public route identification. |
+| runs_pieces.txt | TODS-Specific | Defines daily personnel schedules within a feed. |
+| run_events.txt | TODS-Specific| Defines other scheduled activities to be performed by a member of personnel during a run. |
 
-| **Field Name** | **Type** | **Required** | **Description** |
-| --- | --- | --- | --- |
-| ops_location_id | ID | Required | Identifies an operational location. |
-| ops_location_code | String | Optional | Short text or a number that identifies the operational location for internal use. |
-| ops_location_name | String | Required | Name of the operational location. |
-| ops_location_desc | String | Optional | Description of the operational location. |
-| ops_location_lat | Latitude | Required | The latitude of the operational location. |
-| ops_location_lon | Longitude | Required | The longitude of the operational location. |
+The use of the `_supplement` standard to modify other GTFS files remains experimental at this time.
 
-### deadhead_times.txt
 
-| **Field Name** | **Type** | **Required** | **Description** |
-| --- | --- | --- | --- |
-| deadhead_id | ID referencing **deadheads.deadhead_id** | Required | Identifies a deadhead. |
-| arrival_time | Time | Required | The time at which the vehicle is scheduled to arrive at the operational location specified by this record. |
-| departure_time | Time | Required | The time at which the vehicle is scheduled to depart from the operational location specified by this record. |
-| ops_location_id | ID referencing **ops_locations.ops_location_id** | Conditionally Required | Identifies the operational location specified by this record.<br /><br />If stop_id is blank, ops_location_id is required. If stop_id is not blank, ops_location_id must be blank. |
-| stop_id | ID referencing **[stops.stop_id](https://developers.google.com/transit/gtfs/reference#stopstxt)** | Conditionally Required | Identifies the stop specified by this record.<br /><br />If ops_location_id is blank, stop_id is required. If ops_location_id is not blank, stop_id must be blank. |
-| location_sequence | Non-negative Integer | Required | Order of locations, including both operational locations and stops, for a particular deadhead. The values must increase along the trip but do not need to be consecutive. |
-| shape_dist_traveled | Non-negative Float | Optional | Actual distance traveled along the associated shape, from the first location to the location specified in this record. |
+## `_supplement` Files
+
+### Structure & Evaluation
+
+The fields in all `_supplement` files match those defined in the corresponding file's [GTFS specification](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md).
+
+Each row in a `_supplement` file is used to modify the corresponding file in GTFS and should be evaluated as follows:
+
+1. If the row's Primary Key is defined in the corresponding GTFS file, and the `TODS_delete` field is equal to `1`, remove the row from the GTFS file.
+2. If the row's Primary Key is defined in the corresponding GTFS file, and the `TODS_delete` field is not defined or not equal to `1`, set or update (in the corresponding GTFS file) the value of any non-blank fields defined in the `_supplement` file's row to the `_supplement`'s value.
+3. If the row's Primary key is NOT defined in the corresponding GTFS file, add the row to the corresponding GTFS file.
+
+In other words, where a primary key matches, the row is either removed or any non-empty values in the row are used to *update* the corresponding GTFS values. Where a primary key match does not exist, the entire row is added.
+
+### TODS-Specific Fields
+
+In addition to the fields defined in GTFS, specific fields for use within TODS are denoted by a `TODS_` field prefix.
+
+| **File** | **Field Name** | **Type** | **Required** | **Description** |
+| --- | --- | --- | --- | --- |
+| Any `_supplement` file | `TODS_delete` | Enum | Optional | (blank) - Update other fields; do not delete.<br>`1` - Deletes the GTFS row in the corresponding file whose primary key matches the value in the `_supplement` file's row. |
+| `trips_supplement.txt` | `TODS_trip_type` | Text | Optional | Defines the type of the trip if distinct from a standard revenue trip. |
+| `stops_supplement.txt` | `TODS_location_type` | Text | Optional | Defines the type of the location if distinct from a standard GTFS location type. Where defined, the GTFS `location_type` shall be ignored. |
+
+
+
+
+
+## TODS-Specific File Definitions
+
 
 ### runs_pieces.txt
 
@@ -57,11 +66,11 @@ The Operational Data Standard was last updated on April 14, 2022 (v1.0). View th
 | run_id | ID | Required | Identifies a run. |
 | piece_id | ID | Required | Identifies the piece of the run. The piece_id field must be unique. |
 | start_type | Enum | Required | Indicates whether the piece begins with a deadhead, a revenue trip, or an event.<br /><br />**0** - Deadhead <br />**1** - Trip <br />**2** - Event |
-| start_trip_id | ID referencing **deadheads.deadhead_id** or [**trips.trip_id**](https://developers.google.com/transit/gtfs/reference#tripstxt) | Required | Identifies the deadhead or trip with which the piece begins. |
-| start_trip_position | Non-negative Integer referencing **deadhead_times.location_sequence** or [**stop_times.stop_sequence**](https://developers.google.com/transit/gtfs/reference#stop_timestxt) | Optional | Identifies the first operational location or stop to be serviced in the first trip of the piece. This field should only be filled out if the piece does not begin at the first stop of the start trip. |
+| start_trip_id | ID referencing **deadheads.deadhead_id** or [**trips.trip_id**](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#tripstxt) | Required | Identifies the deadhead or trip with which the piece begins. |
+| start_trip_position | Non-negative Integer referencing **deadhead_times.location_sequence** or [**stop_times.stop_sequence**](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stop_timestxt) | Optional | Identifies the first operational location or stop to be serviced in the first trip of the piece. This field should only be filled out if the piece does not begin at the first stop of the start trip. |
 | end_type | Enum | Required | Indicates whether the piece ends with a deadhead, a revenue trip, or an event. <br /><br />**0** - Deadhead <br />**1** - Trip <br />**2** - Event |
-| end_trip_id | ID referencing **deadheads.deadhead_id** or [**trips.trip_id**](https://developers.google.com/transit/gtfs/reference#tripstxt) | Required | Identifies the deadhead or trip with which the piece ends. |
-| end_trip_position | Non-negative Integer referencing **deadhead_times.location_sequence** or [**stop_times.stop_sequence**](https://developers.google.com/transit/gtfs/reference#stop_timestxt) | Optional | Identifies the last operational location or stop to be serviced in the last trip of the piece. This field should only be filled out if the piece does not end at the last stop of the end trip. |
+| end_trip_id | ID referencing **deadheads.deadhead_id** or [**trips.trip_id**](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#tripstxt) | Required | Identifies the deadhead or trip with which the piece ends. |
+| end_trip_position | Non-negative Integer referencing **deadhead_times.location_sequence** or [**stop_times.stop_sequence**](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stop_timestxt) | Optional | Identifies the last operational location or stop to be serviced in the last trip of the piece. This field should only be filled out if the piece does not end at the last stop of the end trip. |
 
 ### run_events.txt
 
@@ -74,6 +83,6 @@ The Operational Data Standard was last updated on April 14, 2022 (v1.0). View th
 | event_time | Time | Required | The time at which the event begins. |
 | event_duration | Non-negative Integer | Required | The scheduled duration of the event from the event_time in seconds. |
 | event_from_location_type | Enum | Optional | Indicates whether the event is scheduled to begin at an operational location or a stop.<br /><br />**0** - Operational Location<br />**1** - Stop |
-| event_from_location_id | ID referencing **ops_locations.ops_location_id** or [**stops.stop_id**](https://developers.google.com/transit/gtfs/reference#stopstxt) | Optional | Identifies the operational location or stop at which the event is scheduled to begin. |
+| event_from_location_id | ID referencing **ops_locations.ops_location_id** or [**stops.stop_id**](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stopstxt) | Optional | Identifies the operational location or stop at which the event is scheduled to begin. |
 | event_to_location_type | Enum | Optional | Indicates whether the event is scheduled to end at an operational location or a stop.<br /><br />**0** - Operational Location<br />**1** - Stop |
-| event_to_location_id | ID referencing **ops_locations.ops_location_id** or [**stops.stop_id**](https://developers.google.com/transit/gtfs/reference#stopstxt) | Optional | Identifies the operational location or stop at which the event is scheduled to end. |
+| event_to_location_id | ID referencing **ops_locations.ops_location_id** or [**stops.stop_id**](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stopstxt) | Optional | Identifies the operational location or stop at which the event is scheduled to end. |# Reference

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -42,6 +42,10 @@ Each row in a `_supplement` file is used to modify the corresponding file in GTF
 
 In other words, where a primary key matches, the row is either removed or any non-empty values in the row are used to *update* the corresponding GTFS values. Where a primary key match does not exist, the entire row is added.
 
+> _**Implications and Guidance:**_
+> - To explicitely blank a field, delete the row entirely using the `TODS_delete` field and then re-add the row with the desired values subsequent thereto.
+> - If a row contains defined values besides the Primary Key and a `TODS_delete` value of `1`, the row shall be removed and other values in that row will be ignored.
+
 ### TODS-Specific Fields
 
 In addition to the fields defined in GTFS, specific fields for use within TODS are denoted by a `TODS_` field prefix.


### PR DESCRIPTION
Proposed documentation for implementation per #55 and discussion on prior working group calls.

* Establishes the standard structure for `_supplement` files and enumerates those provisioned for use with standardized fields.
* Updates GTFS reference links to the GTFS repo itself (vs the deprecated Google Transit webpage).
* Updates the reference language in this file to TODS (for Transit Operational Data Standard per 2/27/24 call), although other files remain to be updated.
* Leaves the runs_pieces.txt and run_events.txt files unmodified in anticipation of a pull request to implement the changes of #60.

An open question remains as to the preferred handling of the `TODS_trip_type` and `TODS_location_type` fields, both in their nomenclature and their implementation as a text string (vs enum). I have proposed the two above based on handling in the analogous GTFS files and prior working group discussion about the value of text strings vs enums for varying types needing to be defined by individual operators, although these could certainly be changed per future discussions.