### PR TITLE
fix lint errors

### DIFF
--- a/docs/governance/governance.md
+++ b/docs/governance/governance.md
@@ -34,7 +34,7 @@ The TODS Governance is designed with the following principles in mind:
 
 The TODS Project encompasses:
 
-- [TODS Specification](#operational-data-standard-tods-specification)
+- [TODS Specification](#tods-specification)
 - [TODS Tools](#tods-tools)
 - [TODS Repository](#tods-repository)
 - [TODS Documentation](#tods-documentation)
@@ -67,15 +67,15 @@ Agreement for behavior within the [TODS Community](#tods-community) which must b
 
 ### TODS Change Management + Versioning Policy
 
-How content of the [TODS Specification](#operational-data-standard-tods-specification) may be changed and released as an official [TODS version](policies/change-management-versioning.md#tods-release).
+How content of the [TODS Specification](#tods-specification) may be changed and released as an official [TODS version](policies/change-management-versioning.md#tods-release).
 
 ### TODS Documentation
 
-The text and website (and supporting scripts) which describe the [TODS Specification](#operational-data-standard-TODS-specification) and its purpose and usage located on the [TODS Repository](#tods-repository).
+The text and website (and supporting scripts) which describe the [TODS Specification](#tods-specification) and its purpose and usage located on the [TODS Repository](#tods-repository).
 
 ### TODS Repository
 
-The version control repository containing the [TODS Specification](#operational-data-standard-tods-specification) located at:
+The version control repository containing the [TODS Specification](#tods-specification) located at:
 <https://github.com/cal-itp/operational-data-standard>
 
 ### TODS Repository Organization
@@ -92,7 +92,7 @@ Any scripts or code released within the [TODS Repository Organization](#tods-rep
 
 ### TODS Use License
 
-The [TODS Specification](#operational-data-standard-tods-specification) is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) (code) and [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/) (sample data, specification, and documentation) as defined in [`LICENSES`](https://github.com/cal-itp/operational-data-standard/blob/main/LICENSES) file in the [GitHub repository](https://github.com/cal-itp/operational-data-standard).
+The [TODS Specification](#tods-specification) is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) (code) and [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/) (sample data, specification, and documentation) as defined in [`LICENSES`](https://github.com/cal-itp/operational-data-standard/blob/main/LICENSES) file in the [GitHub repository](https://github.com/cal-itp/operational-data-standard).
 
 ## Roles
 
@@ -109,16 +109,16 @@ Responsibility for the governance of the TODS Project is divided among the follo
 
 ## TODS Owner
 
-The TODS Project is collectively owned and overseen by the [TODS Board of Directors](#TODS-board-of-directors).
+The TODS Project is collectively owned and overseen by the [TODS Board of Directors](#tods-board-of-directors).
 
 ## TODS Board of Directors
 
 The TODS Board of Directors ("TODS Board") governs and collectively owns the [TODS Project](#tods-project).
 
-- The Board MAY select an individual or organization to serve as the [TODS Manager](#tods-manager) to handle the day-to-day management of the [TODS Specification](#operational-data-standard-tods-specification) and [TODS Project](#tods-project).
-- The [TODS Board](#tods-board-of-directors) MUST execute a memorandum of understanding with the [TODS Manager](#TODS-manager) (if one is chosen) that outlines the roles, responsibilities, and limitations of the management role.
+- The Board MAY select an individual or organization to serve as the [TODS Manager](#tods-manager) to handle the day-to-day management of the [TODS Specification](#tods-specification) and [TODS Project](#tods-project).
+- The [TODS Board](#tods-board-of-directors) MUST execute a memorandum of understanding with the [TODS Manager](#tods-manager) (if one is chosen) that outlines the roles, responsibilities, and limitations of the management role.
 - The [TODS Board](#tods-board-of-directors) MAY change the [TODS Manager](#tods-manager) at any time for any reason.
-- In the event that there is not an active agreement with an [TODS Manager](#tods-manager) the [TODS Board](#TODS-board-of-directors) MUST assume the [TODS Manager](#tods-manager) responsibilities.
+- In the event that there is not an active agreement with an [TODS Manager](#tods-manager) the [TODS Board](#tods-board-of-directors) MUST assume the [TODS Manager](#tods-manager) responsibilities.
 - The [TODS Board](#tods-board-of-directors) SHOULD ask the [TODS Manager](#tods-manager) to select a new [TODS Program Manager](#tods-program-manager) if there is continued failure to perform and meet expectations.
 - [TODS Board](#tods-board-of-directors) membership MUST be determined by the [Board Composition Policy](policies/board-composition.md).
 - [TODS Board](#tods-board-of-directors) decisionmaking should be consistent with the [Board Decisionmaking Policy](policies/board-decisionmaking.md).

--- a/docs/governance/policies/change-management-versioning.md
+++ b/docs/governance/policies/change-management-versioning.md
@@ -14,7 +14,7 @@ The following definitions build on the overall [TODS Governance][governance] def
 
 ### TODS Release
 
-An official version of the [TODS Specification](../governance.md#tods-specification) which can be referenced in perpetuity by a version number. The process by which a new release is made and determination of a version number is discussed below.
+An official version of the [TODS Specification][tods-spec] which can be referenced in perpetuity by a version number. The process by which a new release is made and determination of a version number is discussed below.
 
 Each change to normative content in the main branch of the TODS Repository MUST be considered a new release and assigned a version number.
 
@@ -28,7 +28,7 @@ Non-normative content is the non-prescriptive, or ‘descriptive’, part of a s
 
 ### Issue Working Group
 
-Tasked by the [TODS Manager][manager] with resolving a specific issue with respect to the TODS Specification.
+Tasked by the [TODS Manager][manager] with resolving a specific issue with respect to the [TODS Specification][tods-spec].
 
 ### Urgent Needs
 
@@ -36,7 +36,7 @@ Urgent needs MUST pose significant risks to security, compliance, or the operati
 
 ## Change-Making Process
 
-This change-making process covers [all normative content changes](#normative-content) to the TODS Specification and occurs in the following stages:
+This change-making process covers [all normative content changes](#normative-content) to the [TODS Specification][tods-spec] and occurs in the following stages:
 
 | Stage | When | Who (led by) |
 |-----|-----|-----|
@@ -51,7 +51,7 @@ Each of these stages is discussed in more detail below.
 
 ### Need Identification
 
-Initiated when Any TODS Contributor identifies a need that should be addressed in the TODS Specification.
+Initiated when Any TODS Contributor identifies a need that should be addressed in the [TODS Specification][tods-spec].
 
 Actions:
 
@@ -131,7 +131,7 @@ Actions:  See [Release Management](#releases).
 
 ## Expedited Change Management
 
-This section outlines an expedited process for implementing changes in response to urgent needs which are critical to maintaining the security, compliance, or operational functionality of TODS Specification balancing rapid response with informed, transparent decision-making.
+This section outlines an expedited process for implementing changes in response to urgent needs which are critical to maintaining the security, compliance, or operational functionality of [TODS Specification][tods-spec] balancing rapid response with informed, transparent decision-making.
 
 ### Process
 
@@ -199,7 +199,7 @@ Pre-release versions MUST be named with the `<MAJOR>.<MINOR>` of their target re
 Non-normative changes MUST NOT increment the TODS Version Number even though they are represented by updates in the `main` branch of the [TODS Repository][repository].
 
 [governance]: ../governance.md
-[tods-spec]: ../governance.md#operational-data-standard-tods-specification
+[tods-spec]: ../governance.md#tods-specification
 [repository]: ../governance.md#tods-repository
 [manager]: ../governance.md#tods-manager
 [board]: ../governance.md#tods-board-of-directors

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,11 +70,9 @@ TODS 1.0
 
 :material-check-circle-outline: [Giro Hastus](https://www.giro.ca/) (on request)
 
-
 TODS 2.0
 
 :material-check-circle-outline: [MBTA](http://mbta.com) (in progress)
-
 
 ## How do I implement TODS?
 

--- a/docs/spec/examples.md
+++ b/docs/spec/examples.md
@@ -1,4 +1,4 @@
-f# Examples
+# Examples
 
 The following sections provide examples of how TODS can represent specific use cases. The inclusion of these examples should not
 be as an indication that this is the only way to represent these use cases with TODS. If you have questions about a use case not

--- a/docs/spec/revision-history.md
+++ b/docs/spec/revision-history.md
@@ -3,9 +3,10 @@
 ## 20 June 2024
 
 TODS v2.0.0-alpha.1 is adopted.
+
 * Removes files `deadheads.txt`, `ops_locations.txt`, `deadhead_times.txt`.
 * Adds new files `trips_supplement.txt`, `stops_supplement.txt`, `stop_times_supplement.txt`, and `routes_supplement.txt`.
-   * Allows for supplementation, modification, and/or deletion of data in existing GTFS feed.
+    * Allows for supplementation, modification, and/or deletion of data in existing GTFS feed.
 
 ## 3 May 2022
 


### PR DESCRIPTION
CI is failing with a bunch of lint errors, mostly broken links. This should fix them.

[Example CI failure](https://github.com/cal-itp/operational-data-standard/actions/runs/13634770938/job/38110682010)
```
markdownlint.............................................................Failed
- hook id: markdownlint
- exit code: 1

docs/governance/governance.md:37:3 MD051/link-fragments Link fragments should be valid [Context: "[TODS Specification](#operational-data-standard-tods-specification)"]
docs/governance/governance.md:70:20 MD051/link-fragments Link fragments should be valid [Context: "[TODS Specification](#operational-data-standard-tods-specification)"]
docs/governance/governance.md:74:66 MD051/link-fragments Link fragments should be valid [Context: "[TODS Specification](#operational-data-standard-TODS-specification)"]
docs/governance/governance.md:78:47 MD051/link-fragments Link fragments should be valid [Context: "[TODS Specification](#operational-data-standard-tods-specification)"]
docs/governance/governance.md:95:5 MD051/link-fragments Link fragments should be valid [Context: "[TODS Specification](#operational-data-standard-tods-specification)"]
docs/governance/governance.md:112:60 MD051/link-fragments Link fragments should be valid [Expected: #tods-board-of-directors; Actual: #TODS-board-of-directors] [Context: "[TODS Board of Directors](#TODS-board-of-directors)"]
docs/governance/governance.md:118:143 MD051/link-fragments Link fragments should be valid [Context: "[TODS Specification](#operational-data-standard-tods-specification)"]
docs/governance/governance.md:119:98 MD051/link-fragments Link fragments should be valid [Expected: #tods-manager; Actual: #TODS-manager] [Context: "[TODS Manager](#TODS-manager)"]
docs/governance/governance.md:121:96 MD051/link-fragments Link fragments should be valid [Expected: #tods-board-of-directors; Actual: #TODS-board-of-directors] [Context: "[TODS Board](#TODS-board-of-directors)"]
docs/index.md:73 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
docs/index.md:78 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
docs/governance/policies/change-management-versioning.md:202:1 MD053/link-image-reference-definitions Link and image reference definitions should be needed [Unused link or image reference definition: "tods-spec"] [Context: "[tods-spec]: ../governance.md#..."]
docs/spec/examples.md:1 MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading [Context: "f# Examples"]
docs/spec/revision-history.md:6 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* Removes files `deadheads.txt..."]
docs/spec/revision-history.md:8:1 MD007/ul-indent Unordered list indentation [Expected: 4; Actual: 3]
```
