### PR TITLE
Added new sub-section + extensions

### DIFF
--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -74,6 +74,9 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_div_format
   - pymdownx.smartsymbols
+  - pymdownx.caret
+  - pymdownx.mark
+  - pymdownx.tilde
   - meta
   - toc:
       # insert a blank space before the character
@@ -110,6 +113,7 @@ nav:
     - Handouts + Presentations: resources/resources.md
     - Frequently Asked Questions: resources/faq.md
     - Implementation Guide: resources/implementation-guide.md
+    - Upcoming Engagements: resources/upcoming-engagements.md
 
 copyright: |
   <div class="container">

--- a/docs/en/resources/upcoming-engagements.md
+++ b/docs/en/resources/upcoming-engagements.md
@@ -1,0 +1,17 @@
+# Upcoming Engagements
+
+<h2>Representatives of the TODS project are expecting to attend:</h2>
+
+<h3>2026</h3>
+
+* 2026-06-23/25 — [TransitData 2026](https://www.transitdata2026.ca/) — _Toronto, Ontario, Canada_
+* 2026-08-09/12 — [APTAtech](https://www.cgi.com/us/en-us/event/cgi-advantage/aptatech) — _St. Louis, Missouri, United States of America_
+* 2026-09-22/23 — [International Mobility Data Summit](https://mobilitydata.org/2026-international-mobility-data-summit/) — _Montreal, Quebec, Canada_
+* 2026-10-04/07 — [APTA TRANSform](https://www.aptaexpo.com/) — _Chicago, Illinois, United States of America_
+* 2026-10-TBA — [TransportationCamp NYC](https://transportationcamp.org/) — _Brooklyn, Mew York, United States of America_
+* 2026-10-TBA — [TransportationCamp New England](https://transportationcamp.org/) — _Boston, Massachusetts, United States of America_
+
+<h3>2027</h3>
+
+* 2027-01-10 — [TransportationCamp DC](https://transportationcamp.org/) — _Washington D.C., United States of America_
+* 2027-01-11/15 — [TRBAM](https://www.nationalacademies.org/events/886) — _Washington D.C., United States of America_


### PR DESCRIPTION
Added new section in Resources, addresses https://github.com/MobilityData/transit-operational-data-standard/issues/139

<img width="1758" height="1192" alt="Screenshot 2026-03-31 at 10 52 39" src="https://github.com/user-attachments/assets/aec74b82-fd61-4b8c-bb2e-78e3140ff3c1" />
