### PR TITLE
examples: fix duplicate event_sequence in Run as Directed work example

### DIFF
--- a/docs/en/spec/examples.md
+++ b/docs/en/spec/examples.md
@@ -166,7 +166,7 @@ service_id,run_id,event_sequence,block_id,event_type,trip_id,start_location,star
 weekday,10000,10,       ,sign-in        ,,garage,08:45:00,garage,08:50:00
 weekday,10000,20,BLOCK-A,deadhead       ,,garage,08:50:00,stop-1,09:00:00
 weekday,10000,30,BLOCK-A,run-as-directed,,stop-1,09:00:00,stop-1,12:00:00
-weekday,10000,30,BLOCK-A,deadhead       ,,stop-1,12:00:00,garage,12:10:00
+weekday,10000,40,BLOCK-A,deadhead       ,,stop-1,12:00:00,garage,12:10:00
 ```
 
 ## Jobs of entirely nonrevenue operations


### PR DESCRIPTION
The `run_events.txt` block in the [Run as Directed work example](https://tods-transit.org/spec/examples/#run-as-directed-work) uses `event_sequence` 30 on two rows of run `(weekday, 10000)`:

  ```
  weekday,10000,30,BLOCK-A,run-as-directed,,stop-1,09:00:00,stop-1,12:00:00
  weekday,10000,30,BLOCK-A,deadhead,,stop-1,12:00:00,garage,12:10:00
  ```

`run_events.txt` declares Primary Key `(service_id, run_id, event_sequence)` and states `event_sequence` "Must be unique within one (`service_id`, `run_id`)", so the example contradicts its own rule. The two events are sequential (09:00 to 12:00, then 12:00 to 12:10), so this bumps the trailing deadhead to `40` (any non-duplicate value works, since sequences need not be consecutive).

  Per the design discussion in #60, `event_sequence` values "must be different" even when two events share a start/end time, so this looks like a slip in the example rather than an intended tie. I found this while building a TODS validator, and I'm happy to adjust if `40` isn't the preferred convention.